### PR TITLE
fix(backend): exclude tests from tsc build

### DIFF
--- a/Backend/tsconfig.json
+++ b/Backend/tsconfig.json
@@ -4,26 +4,24 @@
     // File Layout
     "rootDir": "./src",
     "outDir": "./dist",
-
     // Environment Settings
     // See also https://aka.ms/tsconfig/module
     "module": "nodenext",
     "target": "esnext",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     // For nodejs:
     // "lib": ["esnext"],
     // "types": ["node"],
     // and npm install -D @types/node
-
     // Other Outputs
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-
     // Stricter Typechecking Options
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-
     // Style Options
     // "noImplicitReturns": true,
     // "noImplicitOverride": true,
@@ -31,7 +29,6 @@
     // "noUnusedParameters": true,
     // "noFallthroughCasesInSwitch": true,
     // "noPropertyAccessFromIndexSignature": true,
-
     // Recommended Options
     "strict": true,
     // "jsx": "react-jsx", // backend only
@@ -39,6 +36,16 @@
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",
-    "skipLibCheck": true,
-  }
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "tests",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
This pull request updates the TypeScript configuration in `Backend/tsconfig.json` to improve project structure and build performance. The most significant changes are the addition of explicit `include` and `exclude` patterns, which help TypeScript focus only on relevant source files and ignore test and build output files.

TypeScript configuration improvements:

* Added an `include` array to only compile TypeScript files under the `src` directory.
* Added an `exclude` array to prevent TypeScript from processing files in `dist`, `node_modules`, `tests`, and all test files matching `*.test.ts` or `*.spec.ts`.